### PR TITLE
Fix: Addressing app looping due to quick changes of inputs

### DIFF
--- a/R/lait_modules/mod_app_inputs.R
+++ b/R/lait_modules/mod_app_inputs.R
@@ -61,29 +61,24 @@ appInputsServer <- function(id, shared_values) {
 
     # Observe and synchronise LA input across pages
     observe({
-      req(shared_values$la)
       updateSelectInput(session, "la_name", selected = shared_values$la)
     })
 
     observe({
-      req(shared_values$topic)
       updateSelectInput(session, "topic_name", selected = shared_values$topic)
     })
 
     observe({
-      req(shared_values$indicator)
       updateSelectInput(session, "indicator_name", selected = shared_values$indicator)
     })
 
     # Update Indicator dropdown for selected Topic
     shiny::observeEvent(debounced_topic_name(), {
-      req(debounced_topic_name())
       # Get indicator choices for selected topic
       filtered_topic_bds <- bds_metrics |>
         dplyr::filter(.data$Topic == debounced_topic_name()) |>
         pull_uniques("Measure")
 
-      req(filtered_topic_bds)
 
       # Update the Indicator dropdown based on selected Topic
       updateSelectInput(
@@ -99,13 +94,11 @@ appInputsServer <- function(id, shared_values) {
 
     # Observe and synchronise LA input changes
     observeEvent(debounced_la_name(), {
-      req(debounced_la_name())
       shared_values$la <- debounced_la_name()
     })
 
     # Observe and synchronise Indicator input changes
     observeEvent(debounced_indicator_name(), {
-      req(debounced_indicator_name())
       shared_values$indicator <- debounced_indicator_name()
     })
 

--- a/tests/testthat/test-UI-01-basic_load.R
+++ b/tests/testthat/test-UI-01-basic_load.R
@@ -14,8 +14,8 @@ app <- AppDriver$new(
   name = "basic_load",
   height = 846,
   width = 1445,
-  load_timeout = 45 * 1000,
-  timeout = 20 * 1000,
+  load_timeout = 45 * 10000,
+  timeout = 20 * 10000,
   wait = TRUE,
   expect_values_screenshot_args = FALSE # Turn off as we don't need screenshots
 )

--- a/tests/testthat/test-UI-app_inputs.R
+++ b/tests/testthat/test-UI-app_inputs.R
@@ -46,8 +46,8 @@ minimal_app <- shinyApp(minimal_ui, minimal_server)
 
 shinytest_app <- shinytest2::AppDriver$new(
   minimal_app,
-  load_timeout = 45 * 1000,
-  timeout = 20 * 1000,
+  load_timeout = 45 * 10000,
+  timeout = 20 * 10000,
   wait = TRUE
 )
 
@@ -74,6 +74,7 @@ test_that("Deafult inputs", {
 test_that("Change in topic input leads to a change in indicator input", {
   # Set Topic input to Economic Factors
   shinytest_app$set_inputs(`la_level-topic_name` = "Economic Factors")
+  shinytest_app$wait_for_idle()
 
   # Top of the Economic Factors indicators
   expect_equal(

--- a/tests/testthat/test-UI-mod_la_lvl_table.R
+++ b/tests/testthat/test-UI-mod_la_lvl_table.R
@@ -120,8 +120,8 @@ test_that("Check LA charts behave as expected", {
     name = "la-charts",
     height = 1059,
     width = 1461,
-    load_timeout = 45 * 1000,
-    timeout = 20 * 1000,
+    load_timeout = 45 * 10000,
+    timeout = 20 * 10000,
     wait = TRUE,
     variant = shinytest2::platform_variant()
   )
@@ -170,6 +170,7 @@ test_that("Check LA charts behave as expected", {
     `la_inputs-topic_name` = "Key Stage 1",
     la_charts = "Bar chart"
   )
+  app$wait_for_idle()
 
   # Get export values
   la_barchart <- app$get_values(export = c("la_barchart"))


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

## Pull request overview

<!-- Give a general description of why a change is being made, include issue number(s) being fixed if relevant -->

Testers have found the app can enter a forever loop state if changing the app inputs very quickly. This uses shinys `debounce()` to stop this from happening.

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Include screenshots for UI changes where possible. -->

If the app inputs are changed very quickly it can cause them to enter a loop, due to the dependency of the indicator inputs on the topic input. This creates a glitching app switching between two inputs indefinitely.


## What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. Include screenshots for UI changes where possible.-->

Using shiny's `debounce()`, the app inputs have a delayed rendering (until the input changes have settled). This looks to have solved the looping issue, as the inputs won't update until the other have updated.

## Anything else

<!-- Add any notes for people reviewing and testing your code that are appropriate. Tag a @person to review if someone in particular needs to see this. -->

May need to increase the `debounce()` time, currently at 1.5s.

This resolves #28.
