### PR TITLE
Completing accessibility statement

### DIFF
--- a/R/ui_panels/accessibility_panel.R
+++ b/R/ui_panels/accessibility_panel.R
@@ -11,11 +11,19 @@ accessibility_panel <- function() {
       dashboard_title = site_title,
       dashboard_url = "https://department-for-education.shinyapps.io/local-authority-interactive-tool/",
       date_tested = "9th December 2024",
-      date_prepared = "9th December 2024",
-      date_reviewed = "9th December 2024",
+      date_prepared = "17th December 2024",
+      date_reviewed = "17th December 2024",
       issues_contact = "https://github.com/dfe-analytical-services/local-authority-interactive-tool/issues",
-      non_accessible_components = "TBC",
-      specific_issues = "TBC"
+      non_accessible_components = c(
+        "Keyboard navigation within some tables may be limited",
+        "Navigation between pages doesn't trigger automatic screen reader response"
+      ),
+      specific_issues = c(
+        "Some ARIA roles within tables lack particular children elements",
+        "The dashboard lacks a \"skip to main content\" link",
+        "Tables don't have horizontal scroll at all zoom levels where it's needed, cutting off some content",
+        "Context focus does not work fully when navigating between pages"
+      )
     )
   )
 }


### PR DESCRIPTION
## Pull request overview

The EESP accessibility review has been completed and the team made a set of fixes. This updates the dashboard with the completed accessibility statement based on the review process.

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

The dashboard had a range of accessibility issues:

- Needs a skip to main content link adding. 
- Ideally should give users an indication of the download file size as well as the format
- Charts need to have alt text added
- Some markup on the tables seems to be off
- Tables don’t have horizontal scroll until 200%, cuts off some of the table around 150-175% (all tabs)
- When you tab into a page, it’s just saying blank, it’s not focusing on the header, goes for all pages 
- Copy to clipboard icon should be marked as presentational
- Trend arrows in table aren't marked up
- Create your own tables would benefit from a h1 header and then some brief informative text underneath explaining the page before getting into the options 
- h3 header is out of hierarchy in places

## What is the new behaviour?

The above list has now been reduced (in other commits than in this PR) to:

- Needs a skip to main content link adding. 
- Some markup on the tables seems to be off
- Tables don’t have horizontal scroll until 200%, cuts off some of the table around 150-175% (all tabs)
- When you tab into a page, it’s just saying blank, it’s not focusing on the header, goes for all pages 

These are highlighted in the accessibility statement in this PR (and need to be added to the GitHub Issues board for this dashboard).

## Additional notes

On the re-check, I've used Windows narrator to check the alt text on charts and images (alongside just using keyboard navigation to reach each item). 