### PR TITLE
Fix: Removing american Zs

### DIFF
--- a/01_data/02_prod/development_update_log.csv
+++ b/01_data/02_prod/development_update_log.csv
@@ -1,11 +1,19 @@
 "Type","Summary","Details","Date"
-"Feature","Initial message","The development of the new R-Shiny LAIT is now complete! While the tool’s core functionality remains unchanged, the user experience has been significantly enhanced. Key features like interactive charts, easy downloads, and accessibility-friendly styling aim to empower users to extract meaningful insights on children’s services with ease.
-
-Looking ahead, we’re excited about potential future enhancements, such as:
-
-- Visualizing quartile bands for better comparisons.
-- Enabling users to deselect geographies from the LA page charts.
-- Highlighting years where local authorities’ values are statistically above or below average.
-
+"Feature","Initial message","The development of the new R-Shiny LAIT is now complete! While the tool’s core functionality remains unchanged, the user experience has been significantly enhanced. Key features like interactive charts, easy downloads, and accessibility-friendly styling aim to empower users to extract meaningful insights on children’s services with ease.
+
+
+
+Looking ahead, we’re excited about potential future enhancements, such as:
+
+
+
+- Visualising quartile bands for better comparisons.
+
+- Enabling users to deselect geographies from the LA page charts.
+
+- Highlighting years where local authorities’ values are statistically above or below average.
+
+
+
 We’d love to hear your ideas! If you have suggestions for new features, please let us know by submitting a [feature request issue on GitHub](https://github.com/dfe-analytical-services/local-authority-interactive-tool/issues/new/choose).",2024-12-13
 "Chore","Test","Test log for development",2024-12-05

--- a/R/fn_analysis.R
+++ b/R/fn_analysis.R
@@ -321,7 +321,7 @@ filter_region_data_all_la <- function(data, la_names) {
 #' This function filters a given BDS dataset to include only the rows that
 #' match the specified indicators. It removes any rows where the year value
 #' is missing (NA). The filtered dataset can be used for further analysis
-#' or visualization of selected indicators.
+#' or visualisation of selected indicators.
 #'
 #' @param bds_data A data frame containing BDS data, including a column
 #'                 for indicators (`Measure`) and years (`Years`).

--- a/R/fn_plotting.R
+++ b/R/fn_plotting.R
@@ -285,7 +285,7 @@ calculate_y_range <- function(data_long) {
 #'
 #' @return A numeric vector of 'pretty' breaks for y-gridlines, ensuring
 #'   that gridlines extend beyond the minimum and maximum values for better
-#'   visualization.
+#'   visualisation.
 #'
 #' @examples
 #' # Example usage:

--- a/R/lait_modules/mod_create_own_inputs.R
+++ b/R/lait_modules/mod_create_own_inputs.R
@@ -225,7 +225,7 @@ Create_MainInputsServer <- function(id, topic_indicator_full) {
 #' Year Range Input UI
 #'
 #' This function creates a user interface component for selecting a range
-#' of years. It utilizes a picker input to allow users to select one
+#' of years. It utilises a picker input to allow users to select one
 #' or more years from the available options.
 #'
 #' @param id A unique identifier for the Shiny module.

--- a/R/lait_modules/mod_region_charts.R
+++ b/R/lait_modules/mod_region_charts.R
@@ -638,9 +638,9 @@ Region_MultiChartInputUI <- function(id) {
 
 #' Region Multi-Chart Input Server Module
 #'
-#' A server-side module that handles the selection and synchronization of regions
+#' A server-side module that handles the selection and synchronisation of regions
 #' for comparing multiple charts (line and bar). It ensures that the selected regions
-#' for both charts are valid and synchronized. The module also retains the user’s
+#' for both charts are valid and synchronised. The module also retains the user’s
 #' previous selections and updates the UI accordingly.
 #'
 #' @param id The unique module ID used to namespace input and output elements
@@ -655,14 +655,14 @@ Region_MultiChartInputUI <- function(id) {
 #'
 #' @return This function does not return a value directly. It renders the user
 #'   interface elements and ensures that the inputs for the line and bar charts
-#'   are synchronized, valid, and updated based on user selection.
+#'   are synchronised, valid, and updated based on user selection.
 #'
 #' @details The module performs the following tasks:
 #'   - Ensures that only valid region selections (those not equal to the selected
 #'     local authority) are allowed for the line and bar charts.
 #'   - Retains previous selections for both charts and updates the inputs with
 #'     valid options when the user changes the main LA or indicator.
-#'   - Synchronizes the line and bar chart inputs so that they both reflect the
+#'   - Synchronises the line and bar chart inputs so that they both reflect the
 #'     same selected regions, with a maximum of three regions selected for each chart.
 #'   - Returns the selected regions for both the line and bar charts as reactive values
 #'     for use in other parts of the app.

--- a/R/ui_panels/user_guide.R
+++ b/R/ui_panels/user_guide.R
@@ -156,7 +156,7 @@ user_guide_panel <- function() {
                   src = "images/user_guide/Create_Own_save_selections.png",
                   alt = paste(
                     "A screenshot showing the Create Your Own page. The webpage URL",
-                    "is highlighted and an arrow points at it to emphasize where to",
+                    "is highlighted and an arrow points at it to emphasise where to",
                     "copy the URL from."
                   ),
                   class = "user-guide-image"
@@ -833,7 +833,7 @@ user_guide_panel <- function() {
                         src = "images/user_guide/Create_Own_save_selections.png",
                         alt = paste(
                           "A screenshot showing the Create Your Own page. The webpage URL",
-                          "is highlighted and an arrow points at it to emphasize where to",
+                          "is highlighted and an arrow points at it to emphasise where to",
                           "copy the URL from."
                         ),
                         class = "user-guide-image"


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

## Pull request overview

<!-- Give a general description of why a change is being made, include issue number(s) being fixed if relevant -->

There are some words which have the American spelling of using a "z" instead of a "s".

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Include screenshots for UI changes where possible. -->

See overview.


## What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. Include screenshots for UI changes where possible.-->

All "z" changed to "s".

## Anything else

<!-- Add any notes for people reviewing and testing your code that are appropriate. Tag a @person to review if someone in particular needs to see this. -->

May be others to watch out for.
