### PR TITLE
Fix: Correcting Regional Level table download ids

### DIFF
--- a/R/lait_modules/mod_region_table.R
+++ b/R/lait_modules/mod_region_table.R
@@ -310,14 +310,14 @@ RegionLA_TableServer <- function(id, app_inputs, bds_metrics, stat_n_geog) {
     # Download ----------------------------------------------------------------
     # File download text - calculates file size
     ns <- NS(id)
-    output$file_type <- shiny::renderUI({
+    output$download_file_txt <- shiny::renderUI({
       file_type_input_btn(ns("file_type"), region_la_table_raw())
     })
 
     # Download dataset
     Download_DataServer(
       "la_download",
-      reactive(input$download_file_txt),
+      reactive(input$file_type),
       reactive(region_la_table_raw()),
       reactive(c(app_inputs$la(), app_inputs$indicator(), "LA-Regional-Level"))
     )


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

## Pull request overview

<!-- Give a general description of why a change is being made, include issue number(s) being fixed if relevant -->

The Regional Level table downloads were not working.

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. Include screenshots for UI changes where possible. -->

The Regional Level table download text and buttons are not appearing or working respectively.


## What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. Include screenshots for UI changes where possible.-->

This has been fixed. The `id`s of download file text and download file type button were wrong.

The Regional level table downloads now work and the text appears.
