### PR TITLE
handling na in the clean_ldn_region() function.

### DIFF
--- a/R/fn_helper_functions.R
+++ b/R/fn_helper_functions.R
@@ -359,24 +359,31 @@ mute_cat <- function(input) {
 #'
 #' @export
 clean_ldn_region <- function(region, filtered_bds) {
-  # Return early if the region doesn't start with "London"
-  if (!grepl("^London", region)) {
+  # Return early if region is NA or doesn't start with "London"
+  if (is.na(region) || !stringr::str_starts(region, "London")) {
     return(region)
   }
 
-  # Extract values for the given region
-  ldn_values <- filtered_bds |>
-    dplyr::filter(`LA and Regions` == region) |>
+  # Check if required columns exist in filtered_bds
+  if (!all(c("LA and Regions", "values_num", "Years_num") %in% colnames(filtered_bds))) {
+    stop("filtered_bds must contain 'LA and Regions', 'values_num', and 'Years_num' columns")
+  }
+
+  # Determine the latest year available in the dataset
+  latest_year <- max(filtered_bds$Years_num, na.rm = TRUE)
+
+  # Extract values for the given region in the latest year
+  latest_values <- filtered_bds |>
+    dplyr::filter(`LA and Regions` == region, Years_num == latest_year) |>
     dplyr::pull(values_num)
 
-  # Return "London" if all values are NA, otherwise return the original region
-  if (all(is.na(ldn_values))) {
+  # Return "London" if the value is NA for the latest year, otherwise return the original region
+  if (all(is.na(latest_values))) {
     return("London")
-  } else {
-    return(region)
   }
-}
 
+  return(region)
+}
 
 #' Retrieve AF Colours Without Warning Message
 #'


### PR DESCRIPTION

## Pull request overview

LA table fixed to show correct data for London instead of NA

## Pull request checklist

Please check if your PR fulfills the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [ ] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

London data only showed in the LA table if all available years of data for London inner/outer (depending on the relevant LA) were NA. This should now be fixed in the fn helper functions script.

## What is the new behaviour?

London data should show instead of London inner/outer, if the latest year of data in the LA's relevant corresponding inner or outer record is NA.
