### PR TITLE
Fix: Specified version of R to use in automated-tests.yaml

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -19,6 +19,7 @@ jobs:
      
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: '4.4.1'
           use-public-rspm: true
           
       - name: Install git2r dependencies

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: '4.4.1'}
 
     permissions:
       contents: read # for checkout to fetch code
@@ -34,6 +34,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
       - name: restore renv


### PR DESCRIPTION
This is to ensure compatibility with older package binaries


## Pull request overview

I'm updating the automated tests to ensure they run on a specific version of R - this matches the behaviour in other areas of the code.

#122 This Pull Request will close this issue

Pinning to R 4.4.1 (Stable) ensures we utilize the RStudio Public Package Manager (RSPM) binaries. This avoids the R_ext/PrtUtil.h header error encountered when the runner attempts to compile Rcpp 1.0.14 (and possibly others) from source on experimental R versions (4.5/4.6).

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

Tests run on the most recent version of R.


## What is the new behaviour?

Tests will run on R 4.4.1

## Anything else

@AStoker830 @Hl-b2 
